### PR TITLE
Raise errors on setup failure and logging with OmniAuth::Strategy::log method

### DIFF
--- a/lib/omniauth/strategies/keycloak-openid.rb
+++ b/lib/omniauth/strategies/keycloak-openid.rb
@@ -1,6 +1,7 @@
 require 'omniauth'
 require 'omniauth-oauth2'
 require 'json/jwt'
+require 'uri'
 
 module OmniAuth
     module Strategies
@@ -23,7 +24,8 @@ module OmniAuth
 
                     raise_on_failure = options.client_options.fetch(:raise_on_failure, false)
 
-                    config_url = "#{options.client_options[:site]}/auth/realms/#{realm}/.well-known/openid-configuration"
+                    config_url = URI.join(site, "/auth/realms/#{realm}/.well-known/openid-configuration")
+
                     log :debug, "Going to get Keycloak configuration. URL: #{config_url}"
                     response = Faraday.get config_url
                     if (response.status == 200)
@@ -31,8 +33,8 @@ module OmniAuth
 
                         @certs_endpoint = json["jwks_uri"]
                         @userinfo_endpoint = json["userinfo_endpoint"]
-                        @authorize_url = json["authorization_endpoint"].gsub(site, "")
-                        @token_url = json["token_endpoint"].gsub(site, "")
+                        @authorize_url = URI(json["authorization_endpoint"]).path
+                        @token_url = URI(json["token_endpoint"]).path
 
                         log_config(json)
 

--- a/lib/omniauth/strategies/keycloak-openid.rb
+++ b/lib/omniauth/strategies/keycloak-openid.rb
@@ -5,40 +5,78 @@ require 'json/jwt'
 module OmniAuth
     module Strategies
         class KeycloakOpenId < OmniAuth::Strategies::OAuth2
+
+            class Error < RuntimeError; end
+            class ConfigurationError < Error; end
+            class IntegrationError < Error; end
+
             attr_reader :authorize_url
             attr_reader :token_url
             attr_reader :cert
 
             def setup_phase
                 if @authorize_url.nil? || @token_url.nil?
+                    prevent_site_option_mistake
+
                     realm = options.client_options[:realm].nil? ? options.client_id : options.client_options[:realm]
                     site = options.client_options[:site]
-                    response = Faraday.get "#{options.client_options[:site]}/auth/realms/#{realm}/.well-known/openid-configuration"
+
+                    raise_on_failure = options.client_options.fetch(:raise_on_failure, false)
+
+                    config_url = "#{options.client_options[:site]}/auth/realms/#{realm}/.well-known/openid-configuration"
+                    log :debug, "Going to get Keycloak configuration. URL: #{config_url}"
+                    response = Faraday.get config_url
                     if (response.status == 200)
                         json = MultiJson.load(response.body)
+
                         @certs_endpoint = json["jwks_uri"]
                         @userinfo_endpoint = json["userinfo_endpoint"]
                         @authorize_url = json["authorization_endpoint"].gsub(site, "")
                         @token_url = json["token_endpoint"].gsub(site, "")
+
+                        log_config(json)
+
                         options.client_options.merge!({
                             authorize_url: @authorize_url,
                             token_url: @token_url
-                        })
+                                                      })
+                        log :debug, "Going to get certificates. URL: #{@certs_endpoint}"
                         certs = Faraday.get @certs_endpoint
                         if (certs.status == 200)
                             json = MultiJson.load(certs.body)
                             @cert = json["keys"][0]
+                            log :debug, "Successfully got certificate. Certificate length: #{@cert.length}"
                         else
-                            #TODO: Throw Error
-                            puts "Couldn't get Cert"
-                        end 
+                            message = "Coundn't get certificate. URL: #{@certs_endpoint}"
+                            log :error, message
+                            raise IntegrationError, message if raise_on_failure
+                        end
                     else
-                        #TODO: Throw Error
-                        puts response.status
+                        message = "Keycloak configuration request failed with status: #{response.status}. " \
+                                  "URL: #{config_url}"
+                        log :error, message
+                        raise IntegrationError, message if raise_on_failure
                     end
                 end
             end
-            
+
+            def prevent_site_option_mistake
+              site = options.client_options[:site]
+              return unless site =~ /\/auth$/
+
+              raise ConfigurationError, "Keycloak site parameter should not include /auth part, only domain. Current value: #{site}"
+            end
+
+            def log_config(config_json)
+              log_keycloak_config = options.client_options.fetch(:log_keycloak_config, false)
+              log :debug, "Successfully got Keycloak config"
+              log :debug, "Keycloak config: #{config_json}" if log_keycloak_config
+              log :debug, "Certs endpoint: #{@certs_endpoint}"
+              log :debug, "Userinfo endpoint: #{@userinfo_endpoint}"
+              log :debug, "Authorize url: #{@authorize_url}"
+              log :debug, "Token url: #{@token_url}"
+            end
+
             def build_access_token
                 verifier = request.params["code"]
                 client.auth_code.get_token(verifier, 

--- a/spec/omniauth/strategies/keycloak_spec.rb
+++ b/spec/omniauth/strategies/keycloak_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe OmniAuth::Strategies::KeycloakOpenId do
       stub_request(:get, "http://localhost:8080/auth/realms/example-realm/protocol/openid-connect/certs")
         .to_return(status: 404, body: "", headers: {})
       OmniAuth::Strategies::KeycloakOpenId.new('keycloak-openid', 'Example-Client', 'b53c572b-9f3b-4e79-bf8b-f03c799ba6ec',
-        client_options: {site: 'http://localhost:8080', realm: 'example-realm'})
+        client_options: {site: 'http://localhost:8080/', realm: 'example-realm'})
     end
     
     it 'should have the correct keycloak token url' do


### PR DESCRIPTION
Hello, @ccrockett !

Thank you for the gem and your work!

I implemented TODOs about raising errors and also added logging of setup.
I use `log` method defined in `OmniAuth::Strategy` module.
https://github.com/omniauth/omniauth/blob/master/lib/omniauth/strategy.rb#L162

If this PR is too big and not cohesive enough, I'll separate it into two or more PR-s. 
Please, let me know.