### PR TITLE
Added base_url parameter to client_options.

### DIFF
--- a/lib/omniauth/strategies/keycloak-openid.rb
+++ b/lib/omniauth/strategies/keycloak-openid.rb
@@ -19,12 +19,13 @@ module OmniAuth
                 if @authorize_url.nil? || @token_url.nil?
                     prevent_site_option_mistake
 
+                    auth_url = "/#{options.client_options[:base_url]}" if options.client_options[:base_url]
                     realm = options.client_options[:realm].nil? ? options.client_id : options.client_options[:realm]
                     site = options.client_options[:site]
 
                     raise_on_failure = options.client_options.fetch(:raise_on_failure, false)
 
-                    config_url = URI.join(site, "/auth/realms/#{realm}/.well-known/openid-configuration")
+                    config_url = URI.join(site, "#{auth_url}/realms/#{realm}/.well-known/openid-configuration")
 
                     log :debug, "Going to get Keycloak configuration. URL: #{config_url}"
                     response = Faraday.get config_url
@@ -81,14 +82,14 @@ module OmniAuth
 
             def build_access_token
                 verifier = request.params["code"]
-                client.auth_code.get_token(verifier, 
+                client.auth_code.get_token(verifier,
                     {:redirect_uri => callback_url.gsub(/\?.+\Z/, "")}
-                    .merge(token_params.to_hash(:symbolize_keys => true)), 
+                    .merge(token_params.to_hash(:symbolize_keys => true)),
                     deep_symbolize(options.auth_token_params))
             end
 
             uid{ raw_info['sub'] }
-        
+
             info do
             {
                 :name => raw_info['name'],
@@ -97,13 +98,13 @@ module OmniAuth
                 :last_name => raw_info['family_name']
             }
             end
-        
+
             extra do
             {
                 'raw_info' => raw_info
             }
             end
-        
+
             def raw_info
                 id_token_string = access_token.token
                 jwk = JSON::JWK.new(@cert)


### PR DESCRIPTION
As described in issue #19 , our Keycloak authenthication servers do not include the /auth/ chunk in their URL.
So I propose to pass this part to the omniauth callback as **base_url** parameter.

The impact is high on existing implementations, because it requires the client configuration to be updated. 
Thus it removes the hardcoded **/auth/** url base.

I hope this proposal is useful.