### PR TITLE
Add ability to get params from request and pass thru to keycloak url

### DIFF
--- a/lib/omniauth/strategies/keycloak-openid.rb
+++ b/lib/omniauth/strategies/keycloak-openid.rb
@@ -98,6 +98,11 @@ module OmniAuth
                     deep_symbolize(options.auth_token_params))
             end
 
+            def request_phase
+                options.authorize_options.each {|key| options[key] = request.params[key.to_s] }
+                super
+            end
+
             uid{ raw_info['sub'] }
 
             info do


### PR DESCRIPTION
added the ability to put `authorize_options` keys in the setup, then pass thru those request params to keycloak

`config/initializers/omniauth.rb:`
```
Rails.application.config.middleware.use OmniAuth::Builder do
  provider :keycloak_openid, 'myclient', '',
    client_options: {scope: [:user], site: 'http://localhost:8080', realm: 'myrealm', base_url: ''},
    authorize_options: [:ui_locale],
    name: 'keycloak'
end
```
`app/views/logins/index.html.erb:`
```
<%= form_tag('/auth/keycloak', method: 'post', data: {turbo: false}) do %>
  <%= hidden_field_tag :ui_locale, 'en' %>
  <button type='submit'>Login with Keycloak</button>
<% end %>
```