### PR TITLE
expose id_token inside extra hash of auth hash

### DIFF
--- a/lib/omniauth/strategies/keycloak-openid.rb
+++ b/lib/omniauth/strategies/keycloak-openid.rb
@@ -110,7 +110,8 @@ module OmniAuth
 
             extra do
             {
-                'raw_info' => raw_info
+                'raw_info' => raw_info,
+                'id_token' => access_token['id_token']
             }
             end
 


### PR DESCRIPTION
In this PR we are also exposing the `id_token` inside the extra hash of the auth hash. This way any project that is using the omniauth-keycloak can use this id_token to use the RP initiated logout [see here for reference](https://github.com/keycloak/keycloak-documentation/blob/main/securing_apps/topics/oidc/java/logout.adoc). 