### PR TITLE
Fix NoMethodError when querying for JSON Web keys

### DIFF
--- a/lib/omniauth/strategies/keycloak-openid.rb
+++ b/lib/omniauth/strategies/keycloak-openid.rb
@@ -47,7 +47,7 @@ module OmniAuth
                         log :debug, "Going to get certificates. URL: #{@certs_endpoint}"
                         certs = Faraday.get @certs_endpoint
                         if (certs.status == 200)
-                            json = JSON.parse(response.body)
+                            json = JSON.parse(certs.body)
                             @certs = json["keys"]
                             log :debug, "Successfully got certificate. Certificate length: #{@certs.length}"
                         else


### PR DESCRIPTION
When JWKS endpoint returns 200 status code in `setup_phase` method call. Following error is shown:

![image](https://user-images.githubusercontent.com/11016113/180761356-62d9c9c3-2992-4690-8937-d9b2e2018f1b.png)

The fix is to use `certs` variable instead of `response` which is response from config url instead. After this change I was able to use Keycloak locally with Rails app.