### PR TITLE
Opt-in for MFA requirement

### DIFF
--- a/omniauth-keycloak.gemspec
+++ b/omniauth-keycloak.gemspec
@@ -22,6 +22,13 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.metadata = {
+    'bug_tracker_uri' => 'https://github.com/ccrockett/omniauth-keycloak/issues',
+    'changelog_uri' => 'https://github.com/ccrockett/omniauth-keycloak/blob/master/CHANGELOG.md',
+    'homepage_uri' => 'https://github.com/ccrockett/omniauth-keycloak',
+    'rubygems_mfa_required' => 'true',
+    'source_code_uri' => 'https://github.com/ccrockett/omniauth-keycloak'
+  }
 
   spec.add_dependency "omniauth", ">= 2.0"
   spec.add_dependency "omniauth-oauth2", ">= 1.7", "< 1.9"


### PR DESCRIPTION
Make the gem more secure by requiring that all privileged operations by any of the owners require OTP.

Additionally, add other useful links like:
- Issue tracker
- Changelog
- Homepage
- Source code repository

Ref:
- https://guides.rubygems.org/mfa-requirement-opt-in/
- #54